### PR TITLE
Specify team for generated pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ fulfills the same input contract at the git-branches-resource can be used.
     uri: https://github.com/mygithubuser/my-template-repo
     branch: master
     paths: [ci/templates/*]
-    
+
 # This repo contains any non-secret non-credential config that needs to be
 # passed into your generated pipeline via fly --load-vars-from options
 - name: branch-manager-config
@@ -150,11 +150,14 @@ fulfills the same input contract at the git-branches-resource can be used.
         CONCOURSE_URL: {{CONCOURSE_URL}}
         CONCOURSE_USERNAME: {{CONCOURSE_USERNAME}}
         CONCOURSE_PASSWORD: {{CONCOURSE_PASSWORD}}
+        CONCOURSE_TEAM: {{CONCOURSE_TEAM}} # Add this if you have a team
 ```
 
 You may specify the `CONCOURSE_*` params directly in your pipeline YAML file, but
 since they are sensitive credentials, you should handle them via Concourse's
 support for [template variables](http://concourse.ci/fly-cli.html#parameters).
+
+If you're using the [teams feature](http://concourse.ci/teams.html) and want to add the pipeline to a team other than `main`, specify it in the `CONCOURSE_TEAM` params. If this params is omitted, no team will be specified.
 
 The `BRANCH_RESOURCE_TEMPLATE` and `BRANCH_JOB_TEMPLATE` parameters are paths
 to ERB templates which will be used to dynamically generate a resource and

--- a/tasks/lib/cbm/branch_manager.rb
+++ b/tasks/lib/cbm/branch_manager.rb
@@ -7,7 +7,7 @@ require 'json'
 module Cbm
   # Main class and entry point
   class BranchManager
-    attr_reader :build_root, :url, :username, :password, :resource_template_file
+    attr_reader :build_root, :url, :username, :password, :username, :team, :resource_template_file
     attr_reader :job_template_file, :load_vars_from_entries, :pipeline_name
     attr_reader :common_resources_template, :group_per_branch
 
@@ -16,6 +16,7 @@ module Cbm
       @url = ENV.fetch('CONCOURSE_URL')
       @username = ENV.fetch('CONCOURSE_USERNAME')
       @password = ENV.fetch('CONCOURSE_PASSWORD')
+      @team = ENV.fetch('CONCOURSE_TEAM', nil)
       @resource_template_file = ENV.fetch('BRANCH_RESOURCE_TEMPLATE')
       @job_template_file = ENV.fetch('BRANCH_JOB_TEMPLATE')
       @pipeline_name = ENV.fetch('PIPELINE_NAME', nil)
@@ -40,6 +41,7 @@ module Cbm
         url,
         username,
         password,
+        team,
         pipeline_file,
         load_vars_from_entries,
         pipeline_name_or_default(git_uri)).set_pipeline

--- a/tasks/lib/cbm/pipeline_updater.rb
+++ b/tasks/lib/cbm/pipeline_updater.rb
@@ -8,15 +8,16 @@ module Cbm
     include Logger
     include ProcessHelper
 
-    attr_reader :url, :username, :password, :pipeline_file, :fly_path
+    attr_reader :url, :username, :password, :team, :pipeline_file, :fly_path
     attr_reader :load_vars_from_entries, :pipeline_name
 
     # TODO: do http://www.refactoring.com/catalog/introduceParameterObject.html
     # rubocop:disable Metrics/ParameterLists
-    def initialize(url, username, password, pipeline_file, load_vars_from_entries, pipeline_name)
+    def initialize(url, username, password, team, pipeline_file, load_vars_from_entries, pipeline_name)
       @url = url
       @username = username
       @password = password
+      @team = team
       @pipeline_file = pipeline_file
       @fly_path = "#{Dir.mktmpdir}/fly"
       @load_vars_from_entries = load_vars_from_entries
@@ -27,8 +28,9 @@ module Cbm
       download_fly
 
       log 'Logging into concourse...'
+      team_argument = team != nil && team != "" ? "--team-name=#{team}" : ''
       process(
-        "#{fly_path} --target=concourse login --concourse-url=#{url}",
+        "#{fly_path} --target=concourse login --concourse-url=#{url} #{team_argument}",
         timeout: 5,
         input_lines: [username, password])
 

--- a/tasks/manage-branches.yml
+++ b/tasks/manage-branches.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 
-image_resource: 
+image_resource:
   type: docker-image
-  source: 
+  source:
     repository: tracker/busyboxplus
     tag: ruby-git
 
@@ -18,6 +18,7 @@ params:
   CONCOURSE_URL: null
   CONCOURSE_USERNAME: null
   CONCOURSE_PASSWORD: null
+  CONCOURSE_TEAM: null
 
 run:
   path: concourse-branch-manager/tasks/manage_branches.rb


### PR DESCRIPTION
Concourse 2.0 introduced [teams](http://concourse.ci/teams.html) as a feature. The `fly set-pipeline` command now has the option of specifying the team to create the pipeline under. This PR exposes this functionality. It is backwards compatible in that if a team is not specified, it will omit the `--team-name` argument from the `set-pipeline` command.
