### PR TITLE
Add template for resource_types

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,19 @@ support for [template variables](http://concourse.ci/fly-cli.html#parameters).
 
 If you're using the [teams feature](http://concourse.ci/teams.html) and want to add the pipeline to a team other than `main`, specify it in the `CONCOURSE_TEAM` params. If this params is omitted, no team will be specified.
 
-The `BRANCH_RESOURCE_TEMPLATE` and `BRANCH_JOB_TEMPLATE` parameters are paths
-to ERB templates which will be used to dynamically generate a resource and
-job for each of your branches.  These templates can
+There are several params available to configure the templates. Each is a path to a file containing an ERB template.
+
+* `BRANCH_RESOURCE_TEMPLATE` - resources to be added to each branch
+* `BRANCH_JOB_TEMPLATE` - jobs to be added to each branch
+* `PIPELINE_COMMON_RESOURCES_TEMPLATE` - resources which will be added only once to the pipeline
+* `PIPELINE_RESOURCE_TYPE_TEMPLATE` - [resource _types_](https://concourse.ci/configuring-resource-types.html) to be added to the pipeline
+
+These templates can
 live in your managed repo, but they don't have to - you could add an additional
 resource to the `branch-manager` job to contain them.  More details on this below...
 
 ***TODO: Document PIPELINE_LOAD_VARS_FROM_N params***
 ***TODO: Document PIPELINE_NAME param***
-***TODO: Document PIPELINE_COMMON_RESOURCES_TEMPLATE param***
 ***TODO: Document GROUP_PER_BRANCH param***
 
 ### 3. Edit and update your Concourse pipeline to add the branch-manager group (optional):

--- a/tasks/lib/cbm/branch_manager.rb
+++ b/tasks/lib/cbm/branch_manager.rb
@@ -9,7 +9,7 @@ module Cbm
   class BranchManager
     attr_reader :build_root, :url, :username, :password, :username, :team, :resource_template_file
     attr_reader :job_template_file, :load_vars_from_entries, :pipeline_name
-    attr_reader :common_resources_template, :group_per_branch
+    attr_reader :common_resources_template, :group_per_branch, :resource_type_template_file
 
     def initialize
       @build_root = ENV.fetch('BUILD_ROOT')
@@ -22,6 +22,7 @@ module Cbm
       @pipeline_name = ENV.fetch('PIPELINE_NAME', nil)
       @load_vars_from_entries = parse_load_vars_from_entries
       @common_resources_template = ENV.fetch('PIPELINE_COMMON_RESOURCES_TEMPLATE', nil)
+      @resource_type_template_file = ENV.fetch('PIPELINE_RESOURCE_TYPE_TEMPLATE', nil)
       @group_per_branch = ENV.fetch('GROUP_PER_BRANCH', 'true') == 'true'
     end
 
@@ -36,6 +37,7 @@ module Cbm
         resource_template_file,
         job_template_file,
         common_resources_template,
+        resource_type_template_file,
         group_per_branch).generate
       Cbm::PipelineUpdater.new(
         url,


### PR DESCRIPTION
Concourse has the feature to add custom resources to a pipeline using the [`resource_types`](https://concourse.ci/configuring-resource-types.html) section. This PR exposes the functionality to add resource types to the pipeline generated by the branch manager.
