### PR TITLE
Use specific version of process_helper gem

### DIFF
--- a/tasks/core/setup_process_helper.rb
+++ b/tasks/core/setup_process_helper.rb
@@ -1,4 +1,4 @@
-system('gem install process_helper --no-ri --no-rdoc') ||
+system('gem install process_helper --no-ri --no-rdoc --version 0.0.3') ||
   fail('failed to install process_helper gem')
 require 'rubygems'
 require 'process_helper'


### PR DESCRIPTION
The `process_helper` gem was [updated](https://github.com/thewoolleyman/process_helper/pull/8/files) to no longer support the `input_lines` option, which is used by the code in this repo.

Also, the change to `process_helper` was a [patch bump](https://github.com/thewoolleyman/process_helper/releases/tag/0.0.4), but the API of the library changed. Looks like someone didn't follow semver 😉 