### PR TITLE
This makes running the example easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ It is intended to be used with the
 which is published on Docker Hub at
 [tracker/git-branches-resource](https://hub.docker.com/r/tracker/git-branches-resource/)
 to determine when and which branches should be built.  However, any resource that
-fulfills the same input contract at the git-branches-resource can be used. 
-**NOTE: That there is now an 
+fulfills the same input contract at the git-branches-resource can be used.
+**NOTE: That there is now an
 [identically named git-branches-resource](https://github.com/vito/git-branches-resource)
 which is published on Docker Hub at
 [cfcommunity/git-branches-resource](https://hub.docker.com/r/cfcommunity/git-branches-resource/),
 however, this one is does NOT currently have some of the features which
 [tracker/git-branches-resource](https://hub.docker.com/r/tracker/git-branches-resource/)
 has, such as regex matching and a max branches limit.  The rest of this
-documentation assumes you are using the latter.  Caveat Emptor.** 
+documentation assumes you are using the latter.  Caveat Emptor.**
 
 * (1) The "selected" branches can be based a regex config option passed
   to the git-branches-resource (3) or other resource which fulfills the
@@ -65,7 +65,8 @@ documentation assumes you are using the latter.  Caveat Emptor.**
 
 ### 0. Enable Concourse authentication
 
-* The branch manager will not work with non-authenticating (development mode) Concourse instances. Any password based authentication mecanism will do (Basic, OAuth...)   
+* The branch manager will not work with non-authenticating (development mode) Concourse instances. Any password based authentication mechanism will do (Basic, OAuth...) [Authentication Documentation](https://concourse.ci/authentication.html)
+
 
 ### 1. Edit and update your Concourse pipeline to add the three required concourse-branch-manager resources
 
@@ -314,6 +315,7 @@ To try it out yourself:
     ```
     # secrets.yml
     CONCOURSE_URL: https://my-concourse-server.example.com
+    CONCOURSE_TEAM: my-team-name
     CONCOURSE_USERNAME: my-basic-auth-concourse-username
     CONCOURSE_PASSWORD: my-basic-auth-concourse-password
     ```

--- a/examples/pipelines/branch-manager-example.yml
+++ b/examples/pipelines/branch-manager-example.yml
@@ -4,6 +4,13 @@ groups:
   jobs:
   - branch-manager
 
+# Defines the git-branches-resource
+resource_types:
+- name: git-branches
+  type: docker-image
+  source:
+    repository: tracker/git-branches-resource
+
 resources:
 - name: concourse-branch-manager
   type: git
@@ -75,15 +82,15 @@ jobs:
     trigger: true
   - task: manage-branches
     file: concourse-branch-manager/tasks/manage-branches.yml
-    config:
-      params:
-        BRANCH_RESOURCE_TEMPLATE: template-repo/examples/templates/my-repo-branch-resource-template.yml.erb
-        BRANCH_JOB_TEMPLATE: template-repo/examples/templates/my-repo-branch-job-template.yml.erb
-        PIPELINE_COMMON_RESOURCES_TEMPLATE: template-repo/examples/templates/my-repo-common-resources-template.yml.erb
-        CONCOURSE_URL: {{CONCOURSE_URL}}
-        CONCOURSE_USERNAME: {{CONCOURSE_USERNAME}}
-        CONCOURSE_PASSWORD: {{CONCOURSE_PASSWORD}}
-        PIPELINE_LOAD_VARS_FROM_1: config-repo/examples/config/my-repo-branch-manager-config.yml
-        PIPELINE_LOAD_VARS_FROM_2: credentials-repo/examples/credentials/my-repo-branch-manager-credentials.yml
-        PIPELINE_NAME: cbm-example-branches
-        GROUP_PER_BRANCH: true
+    params:
+      BRANCH_RESOURCE_TEMPLATE: template-repo/examples/templates/my-repo-branch-resource-template.yml.erb
+      BRANCH_JOB_TEMPLATE: template-repo/examples/templates/my-repo-branch-job-template.yml.erb
+      PIPELINE_COMMON_RESOURCES_TEMPLATE: template-repo/examples/templates/my-repo-common-resources-template.yml.erb
+      CONCOURSE_URL: {{CONCOURSE_URL}}
+      CONCOURSE_TEAM: {{CONCOURSE_TEAM}}
+      CONCOURSE_USERNAME: {{CONCOURSE_USERNAME}}
+      CONCOURSE_PASSWORD: {{CONCOURSE_PASSWORD}}
+      PIPELINE_LOAD_VARS_FROM_1: config-repo/examples/config/my-repo-branch-manager-config.yml
+      PIPELINE_LOAD_VARS_FROM_2: credentials-repo/examples/credentials/my-repo-branch-manager-credentials.yml
+      PIPELINE_NAME: cbm-example-branches
+      GROUP_PER_BRANCH: true

--- a/examples/templates/my-repo-branch-job-template.yml.erb
+++ b/examples/templates/my-repo-branch-job-template.yml.erb
@@ -10,8 +10,7 @@
     trigger: true
   - task: my-repo-branch-task
     file: my-repo-branch/examples/tasks/my-repo-branch-task.yml
-    config:
-      params:
+    params:
         BRANCH_NAME: <%= branch_name %>
         EXAMPLE_LOAD_VARS_FROM_CONFIG_KEY: {{EXAMPLE_LOAD_VARS_FROM_CONFIG_KEY}}
         EXAMPLE_LOAD_VARS_FROM_CREDENTIALS_KEY: {{EXAMPLE_LOAD_VARS_FROM_CREDENTIALS_KEY}}


### PR DESCRIPTION
- Included the git-branches resource in the example pipeline, to make the instructions easier to follow
- Updated README.md
- Fixed depreciation warnings 
` DEPRECATION WARNING: Specifying both `file` and `config.params` in a task step is deprecated, use params on task step directly`


